### PR TITLE
Fat source gem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,16 @@ jobs:
           - os: macos
             ruby: 'head'
 
+          - os: windows
+            ruby: 'head'
+            builtin: 'true'
+          - os: ubuntu
+            ruby: '2.6'
+            builtin: 'true'
+          - os: macos
+            ruby: 'head'
+            builtin: 'true'
+
     runs-on: ${{ matrix.os }}-latest
 
     steps:
@@ -28,11 +38,16 @@ jobs:
       - uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }} # passed to ruby/setup-ruby
-          apt-get: 'zint' # Ubuntu
+          apt-get: 'libpng-dev' # Ubuntu
           brew: 'cmake libpng qt5' # macOS
 
+      - name: Ubuntu install zint
+        if: matrix.os == 'ubuntu' && matrix.builtin != 'true'
+        run: |
+          sudo apt update && sudo apt install -y zint
+
       - name: macOS build zint
-        if: matrix.os == 'macos'
+        if: matrix.os == 'macos' && matrix.builtin != 'true'
         run: |
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           wget https://github.com/zint/zint/archive/refs/tags/2.10.0.zip
@@ -45,7 +60,7 @@ jobs:
           sudo make install
 
       - name: Windows install zint
-        if: matrix.os == 'windows'
+        if: matrix.os == 'windows' && matrix.builtin != 'true'
         run: |
           wget https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-zint-2.10.0-1-any.pkg.tar.zst
           pacman -U --noconfirm ./mingw-w64-ucrt-x86_64-zint-2.10.0-1-any.pkg.tar.zst
@@ -57,6 +72,10 @@ jobs:
 
       - name: Bundle install
         run: bundle install
+
+      - name: Compile builtin zint
+        if: matrix.builtin == 'true'
+        run: bundle exec rake compile -- --disable-system-libzint
 
       - name: Run tests
         run: bundle exec rake spec

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@
 /spec/reports/
 /tmp/
 
+/ext/ruby-zint/Makefile
+/ext/ruby-zint/tmp/
+/lib/libzint.so*
+/ports/
+
 # rspec failure tracking
 .rspec_status
 

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,5 @@
 parallel: true
 format: progress
 ruby_version: 2.6
+ignore:
+  - 'ext/ruby-zint/tmp/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,5 @@ gem "chunky_png"
 gem "byebug"
 
 gem "standard", "~> 1.3"
+
+gem "mini_portile2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     ruby-zint (1.0.0)
       ffi (~> 1.15)
+      mini_portile2 (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -15,6 +16,7 @@ GEM
     ffi (1.15.5)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    mini_portile2 (2.8.1)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
@@ -69,6 +71,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   chunky_png
+  mini_portile2
   rake (~> 13.0)
   rspec (~> 3.0)
   ruby-zint!

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,20 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require_relative "lib/zint/zint_recipe"
+
+CLOBBER.include "pkg"
+CLEAN.include "ports"
+CLEAN.include "tmp"
+CLEAN.include "ext/ruby-zint/tmp"
 
 RSpec::Core::RakeTask.new(:spec)
 
 require "standard/rake"
 
 task default: %i[spec standard]
+
+task gem: :build
+task :compile do
+  sh "ruby -C ext/ruby-zint extconf.rb --disable-system-libzint"
+  sh "make -C ext/ruby-zint install RUBYARCHDIR=../../lib"
+end

--- a/ext/ruby-zint/extconf.rb
+++ b/ext/ruby-zint/extconf.rb
@@ -1,0 +1,86 @@
+# #!/usr/bin/env ruby
+
+require "rubygems"
+require "ffi"
+require "fileutils"
+
+if RUBY_PLATFORM.match?(/java/)
+  # JRuby's C extension support is disabled by default, so we can not use it
+
+  # Implement very simple verions of mkmf-helpers used below
+  def enable_config(name, default = nil)
+    if ARGV.include?("--enable-#{name}")
+      true
+    elsif ARGV.include?("--disable-#{name}")
+      false
+    else
+      default
+    end
+  end
+
+  def arg_config(name)
+    ARGV.include?(name)
+  end
+else
+  require "mkmf"
+end
+
+if RUBY_PLATFORM.match?(/darwin/)
+  ENV["SDKROOT"] ||= `xcrun --sdk macosx --show-sdk-path`.chomp
+end
+
+def do_help
+  print <<~HELP
+    usage: ruby #{$0} [options]
+        --enable-system-libzint / --disable-system-libzint
+          Force use of system or builtin libzint library.
+          Default is to prefer system libraries and fallback to builtin.
+  HELP
+  exit! 0
+end
+
+do_help if arg_config("--help")
+
+def libzint_usable?
+  m = Module.new do
+    extend FFI::Library
+
+    ffi_lib(%w[libzint.so.2.10 libzint zint])
+    attach_function(:ZBarcode_Version, [], :int32)
+  end
+
+  (21000...21100) === m.ZBarcode_Version
+rescue LoadError
+  false
+end
+
+def build_bundled_libzint
+  puts "Build"
+  require_relative "../../lib/zint/zint_recipe"
+
+  recipe = Zint::ZintRecipe.new
+  recipe.cook_and_activate
+  recipe.path
+end
+
+unless enable_config("system-libzint", libzint_usable?)
+  # Unable to load libzint library on this system,
+  # so we build our bundled version:
+  libzint_path = build_bundled_libzint
+end
+
+# Create a Makefile which copies the libzint library files to the gem's lib dir.
+File.open("Makefile", "wb") do |mf|
+  mf.puts <<~EOT
+    RUBYARCHDIR = #{RbConfig::MAKEFILE_CONFIG["sitearchdir"].dump}
+    all:
+    clean:
+    install:
+  EOT
+
+  if libzint_path
+    mf.puts <<-EOT
+	cp -r #{libzint_path.dump}/*/libzint* $(RUBYARCHDIR)
+    EOT
+  end
+end

--- a/lib/zint.rb
+++ b/lib/zint.rb
@@ -1,6 +1,7 @@
 require "ffi"
 
 require "zint/version"
+require "zint/dependencies"
 
 # Zint constants
 require "zint/constants/capability_flags"
@@ -162,7 +163,10 @@ module Zint
     raise klass, text
   end
 
-  ffi_lib %w[libzint.so.2.10 libzint zint]
+  root_path = File.expand_path("../..", __FILE__)
+  prefix = FFI::Platform::LIBPREFIX.empty? ? "lib" : FFI::Platform::LIBPREFIX
+  bundled_dll = File.join(root_path, "lib/#{prefix}zint.#{FFI::Platform::LIBSUFFIX}")
+  ffi_lib [bundled_dll, "libzint.so.2.10", "libzint", "zint"]
 
   # Error codes (API return values)
   enum :error_code, [Zint::WARNINGS, Zint::ERRORS].map { |h| h.to_a }.flatten

--- a/lib/zint/dependencies.rb
+++ b/lib/zint/dependencies.rb
@@ -1,0 +1,8 @@
+module Zint
+  ZINT_VERSION = ENV["ZINT_VERSION"] || "2.10.0"
+  # ZINT_SOURCE_URI = "file://#{File.join(File.expand_path("../../../", __FILE__))}/ports/archives/zint-#{ZINT_VERSION}-src.tar.gz"
+  ZINT_SOURCE_URI = "https://downloads.sourceforge.net/zint/zint-#{ZINT_VERSION}-src.tar.gz"
+  ZINT_SOURCE_SHA1 = "e4a8a5ccbc9e1901e4b592ccc80e17184f2ff5e8"
+
+  MINI_PORTILE_VERSION = "~> 2.1"
+end

--- a/lib/zint/zint_recipe.rb
+++ b/lib/zint/zint_recipe.rb
@@ -12,7 +12,6 @@ module Zint
       super("libzint", ZINT_VERSION)
       self.target = File.join(ROOT, "ports")
       self.files = [url: ZINT_SOURCE_URI, sha1: ZINT_SOURCE_SHA1]
-      self.configure_options = []
     end
 
     def cook_and_activate

--- a/lib/zint/zint_recipe.rb
+++ b/lib/zint/zint_recipe.rb
@@ -1,0 +1,28 @@
+require_relative "dependencies"
+require "rubygems"
+# Keep the version constraint in sync with libusb.gemspec
+gem "mini_portile2", Zint::MINI_PORTILE_VERSION
+require "mini_portile2"
+
+module Zint
+  class ZintRecipe < MiniPortileCMake
+    ROOT = File.expand_path("../../..", __FILE__)
+
+    def initialize
+      super("libzint", ZINT_VERSION)
+      self.target = File.join(ROOT, "ports")
+      self.files = [url: ZINT_SOURCE_URI, sha1: ZINT_SOURCE_SHA1]
+      self.configure_options = []
+    end
+
+    def cook_and_activate
+      checkpoint = File.join(target, "#{name}-#{version}-#{host}.installed")
+      unless File.exist?(checkpoint)
+        cook
+        FileUtils.touch checkpoint
+      end
+      activate
+      self
+    end
+  end
+end

--- a/ruby-zint.gemspec
+++ b/ruby-zint.gemspec
@@ -1,4 +1,5 @@
 require_relative "lib/zint/version"
+require_relative "lib/zint/dependencies"
 
 Gem::Specification.new do |spec|
   spec.name = "ruby-zint"
@@ -21,7 +22,11 @@ Gem::Specification.new do |spec|
       (File.expand_path(f) == __FILE__) || f.start_with?(*%w[bin/ test/ spec/ features/ .git .circleci appveyor])
     end
   end
+  spec.files << "ports/archives/zint-#{Zint::ZINT_VERSION}-src.tar.gz"
+
   spec.require_paths = ["lib"]
+  spec.extensions = ["ext/ruby-zint/extconf.rb"]
 
   spec.add_dependency "ffi", "~> 1.15"
+  spec.add_dependency "mini_portile2", Zint::MINI_PORTILE_VERSION
 end

--- a/ruby-zint.gemspec
+++ b/ruby-zint.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["msys2_mingw_dependencies"] = "cmake libpng"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This PR adds zint sources into the gem file and builds it if zint is not available on the system. See the commit message for more description.

- [x] works on Ubuntu
- [x] works on Macos
- [x] works on Windows / Rubyinstaller