### PR TITLE
Init `Zint::Barcode` per keyword arguments instead of option `Hash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,16 @@ end
 png.save("out.png")
 
 # Use vector export
-vector_struct = barcode.to_vector
-# See manual: https://zint.org.uk/manual/chapter/5#buffering-symbols-in-memory-vector
+vec = Zint::Qr.new(value: "Test").to_vector
+png = ChunkyPNG::Image.new(vec.width.to_i, vec.height.to_i, ChunkyPNG::Color::WHITE)
+vec.each_rectangle do |rec|
+  png.rect(rec.x.to_i, rec.y.to_i,
+      rec.x.to_i+rec.width.to_i-1, rec.y.to_i+rec.height.to_i-1,
+      ChunkyPNG::Color::BLACK, ChunkyPNG::Color::BLACK)
+end
+png.save("out.png")
+
+# See also manual: https://zint.org.uk/manual/chapter/5#buffering-symbols-in-memory-vector
 
 # Use file as input
 barcode = Zint::Barcode.new(input_file: "/tmp/test.txt")

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bundle config build.ruby-zint --enable-system-libzint
 ```ruby
 require "zint"
 
-barcode = Zint::Barcode.new(value: "Test", type: Zint::BARCODE_CODE128)
+barcode = Zint::Barcode.new(value: "Test", symbology: Zint::BARCODE_CODE128)
 
 # Export to file
 barcode.to_file(path: "out.png")

--- a/lib/zint/aus_post.rb
+++ b/lib/zint/aus_post.rb
@@ -1,8 +1,8 @@
 module Zint
   # Australia Post 4-State Barcode
   class AusPost < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_AUSPOST, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_AUSPOST, **kwargs)
     end
   end
 end

--- a/lib/zint/aus_redirect.rb
+++ b/lib/zint/aus_redirect.rb
@@ -1,8 +1,8 @@
 module Zint
   # Australia Post Redirection
   class AusRedirect < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_AUSREDIRECT, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_AUSREDIRECT, **kwargs)
     end
   end
 end

--- a/lib/zint/aus_reply.rb
+++ b/lib/zint/aus_reply.rb
@@ -1,8 +1,8 @@
 module Zint
   # Australia Post Reply Paid
   class AusReply < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_AUSREPLY, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_AUSREPLY, **kwargs)
     end
   end
 end

--- a/lib/zint/aus_route.rb
+++ b/lib/zint/aus_route.rb
@@ -1,8 +1,8 @@
 module Zint
   # Australia Post Routing
   class AusRoute < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_AUSROUTE, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_AUSROUTE, **kwargs)
     end
   end
 end

--- a/lib/zint/azrune.rb
+++ b/lib/zint/azrune.rb
@@ -1,8 +1,8 @@
 module Zint
   # Aztec Runes
   class Azrune < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_AZRUNE, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_AZRUNE, **kwargs)
     end
   end
 end

--- a/lib/zint/aztec.rb
+++ b/lib/zint/aztec.rb
@@ -1,8 +1,8 @@
 module Zint
   # Aztec Code
   class Aztec < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_AZTEC, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_AZTEC, **kwargs)
     end
   end
 end

--- a/lib/zint/barcode.rb
+++ b/lib/zint/barcode.rb
@@ -2,7 +2,7 @@ module Zint
   # Base class to represent the barcode
   #
   # @example Create new barcode
-  #   barcode = Zint::Barcode.new(value: "Test", type: Zint::BARCODE_QRCODE, options: {option_1: 1})
+  #   barcode = Zint::Barcode.new(value: "Test", symbology: Zint::BARCODE_QRCODE, option_1: 1)
   #   barcode.to_file(path: "qr.png")
   class Barcode
     include Native
@@ -16,13 +16,14 @@ module Zint
     # @param input_file [String, NilClass] Path to input file with content of the barcode
     # @param type [Integer] Type of barcode
     # @param options [Hash] Specific options for Zint symbol
-    def initialize(value: nil, input_file: nil, type: Zint::BARCODE_CODE128, options: {})
+    def initialize(value: nil, input_file: nil, type: Zint::BARCODE_CODE128, symbology: type, **kwargs)
       raise ArgumentError, "value or input_file must be given!" if value&.empty? && input_file&.empty?
       raise ArgumentError, "input_file not found!" if input_file && !File.exist?(input_file)
 
-      @zint_symbol = create_symbol(type)
-      options.each do |key, value|
-        @zint_symbol[key] = value
+      @zint_symbol = Native.ZBarcode_Create
+      self.symbology = symbology
+      kwargs.each do |k, v|
+        send("#{k}=", v)
       end
 
       @value = value
@@ -528,13 +529,6 @@ module Zint
       end
 
       error_code
-    end
-
-    def create_symbol(type)
-      symbol = Native.ZBarcode_Create
-      symbol[:symbology] = type
-
-      symbol
     end
   end
 end

--- a/lib/zint/barcode.rb
+++ b/lib/zint/barcode.rb
@@ -14,9 +14,9 @@ module Zint
 
     # @param value [String, NilClass] Content of the barcode
     # @param input_file [String, NilClass] Path to input file with content of the barcode
-    # @param type [Integer] Type of barcode
-    # @param options [Hash] Specific options for Zint symbol
-    def initialize(value: nil, input_file: nil, type: Zint::BARCODE_CODE128, symbology: type, **kwargs)
+    # @param symbology [Integer] Type of barcode
+    # @param kwargs [Hash] Specific options for zint symbol (height, scale, ...)
+    def initialize(value: nil, input_file: nil, symbology: Zint::BARCODE_CODE128, **kwargs)
       raise ArgumentError, "value or input_file must be given!" if value&.empty? && input_file&.empty?
       raise ArgumentError, "input_file not found!" if input_file && !File.exist?(input_file)
 

--- a/lib/zint/bc_412.rb
+++ b/lib/zint/bc_412.rb
@@ -1,8 +1,8 @@
 module Zint
   # IBM BC412 (SEMI T1-95)
   class Bc412 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_BC412, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_BC412, **kwargs)
     end
   end
 end

--- a/lib/zint/c25iata.rb
+++ b/lib/zint/c25iata.rb
@@ -1,8 +1,8 @@
 module Zint
   # 2 of 5 IATA
   class C25iata < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_C25IATA, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_C25IATA, **kwargs)
     end
   end
 end

--- a/lib/zint/c25ind.rb
+++ b/lib/zint/c25ind.rb
@@ -1,8 +1,8 @@
 module Zint
   #  2 of 5 Industrial
   class C25ind < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_C25IND, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_C25IND, **kwargs)
     end
   end
 end

--- a/lib/zint/c25inter.rb
+++ b/lib/zint/c25inter.rb
@@ -1,8 +1,8 @@
 module Zint
   # 2 of 5 Interleaved
   class C25inter < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_C25INTER, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_C25INTER, **kwargs)
     end
   end
 end

--- a/lib/zint/c25logic.rb
+++ b/lib/zint/c25logic.rb
@@ -1,8 +1,8 @@
 module Zint
   # 2 of 5 Data Logic
   class C25logic < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_C25LOGIC, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_C25LOGIC, **kwargs)
     end
   end
 end

--- a/lib/zint/c25matrix.rb
+++ b/lib/zint/c25matrix.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class C25matrix < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_C25MATRIX, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_C25MATRIX, **kwargs)
     end
   end
 end

--- a/lib/zint/c25standard.rb
+++ b/lib/zint/c25standard.rb
@@ -1,8 +1,8 @@
 module Zint
   # 2 of 5 Standard (Matrix)
   class C25standard < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_C25STANDARD, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_C25STANDARD, **kwargs)
     end
   end
 end

--- a/lib/zint/cep_net.rb
+++ b/lib/zint/cep_net.rb
@@ -1,8 +1,8 @@
 module Zint
   # Brazilian CEPNet Postal Code
   class CepNet < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CEPNET, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CEPNET, **kwargs)
     end
   end
 end

--- a/lib/zint/channel.rb
+++ b/lib/zint/channel.rb
@@ -1,8 +1,8 @@
 module Zint
   # Channel Code
   class Channel < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CHANNEL, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CHANNEL, **kwargs)
     end
   end
 end

--- a/lib/zint/codabar.rb
+++ b/lib/zint/codabar.rb
@@ -1,8 +1,8 @@
 module Zint
   # Codabar
   class Codabar < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODABAR, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODABAR, **kwargs)
     end
   end
 end

--- a/lib/zint/codablock_f.rb
+++ b/lib/zint/codablock_f.rb
@@ -1,8 +1,8 @@
 module Zint
   # Codablock-F
   class CodablockF < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODABLOCKF, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODABLOCKF, **kwargs)
     end
   end
 end

--- a/lib/zint/code11.rb
+++ b/lib/zint/code11.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code 11
   class Code11 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODE11, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODE11, **kwargs)
     end
   end
 end

--- a/lib/zint/code128.rb
+++ b/lib/zint/code128.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code 128
   class Code128 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODE128, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODE128, **kwargs)
     end
   end
 end

--- a/lib/zint/code128ab.rb
+++ b/lib/zint/code128ab.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code 128 (Suppress Code Set C)
   class Code128AB < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODE128AB, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODE128AB, **kwargs)
     end
   end
 end

--- a/lib/zint/code16k.rb
+++ b/lib/zint/code16k.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code 16k
   class Code16k < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODE16K, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODE16K, **kwargs)
     end
   end
 end

--- a/lib/zint/code32.rb
+++ b/lib/zint/code32.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code 32
   class Code32 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODE32, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODE32, **kwargs)
     end
   end
 end

--- a/lib/zint/code39.rb
+++ b/lib/zint/code39.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code 39
   class Code39 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODE39, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODE39, **kwargs)
     end
   end
 end

--- a/lib/zint/code49.rb
+++ b/lib/zint/code49.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code 49
   class Code49 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODE49, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODE49, **kwargs)
     end
   end
 end

--- a/lib/zint/code93.rb
+++ b/lib/zint/code93.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code 93
   class Code93 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODE93, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODE93, **kwargs)
     end
   end
 end

--- a/lib/zint/code_one.rb
+++ b/lib/zint/code_one.rb
@@ -1,8 +1,8 @@
 module Zint
   # Code One
   class CodeOne < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_CODEONE, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_CODEONE, **kwargs)
     end
   end
 end

--- a/lib/zint/daft.rb
+++ b/lib/zint/daft.rb
@@ -1,8 +1,8 @@
 module Zint
   # DAFT Code
   class Daft < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DAFT, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DAFT, **kwargs)
     end
   end
 end

--- a/lib/zint/data_matrix.rb
+++ b/lib/zint/data_matrix.rb
@@ -10,10 +10,10 @@ module Zint
     DM_EDIFACT = 5
     DM_BASE256 = 6
 
-    def initialize(value: nil, input_file: nil, type: Zint::BARCODE_DATAMATRIX, options: {})
-      raise ArgumentError, "Invalid type for DataMatrix code" unless [Zint::BARCODE_DATAMATRIX, Zint::BARCODE_HIBC_DM].include?(type)
+    def initialize(value: nil, input_file: nil, type: Zint::BARCODE_DATAMATRIX, symbology: type, **kwargs)
+      raise ArgumentError, "Invalid symbology for DataMatrix code" unless [Zint::BARCODE_DATAMATRIX, Zint::BARCODE_HIBC_DM].include?(symbology)
 
-      super(value: value, input_file: input_file, type: type, options: {option_3: Zint::DM_SQUARE}.merge(options))
+      super(value: value, input_file: input_file, symbology: symbology, option_3: Zint::DM_SQUARE, **kwargs)
     end
   end
 end

--- a/lib/zint/dbarexp.rb
+++ b/lib/zint/dbarexp.rb
@@ -1,8 +1,8 @@
 module Zint
   # GS1 DataBar Expanded
   class DbarExp < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DBAR_EXP, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DBAR_EXP, **kwargs)
     end
   end
 end

--- a/lib/zint/dbarexpstk.rb
+++ b/lib/zint/dbarexpstk.rb
@@ -1,8 +1,8 @@
 module Zint
   # GS1 DataBar Expanded Stacked
   class DbarExpstk < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DBAR_EXPSTK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DBAR_EXPSTK, **kwargs)
     end
   end
 end

--- a/lib/zint/dbarltd.rb
+++ b/lib/zint/dbarltd.rb
@@ -1,8 +1,8 @@
 module Zint
   #  GS1 DataBar Limited
   class DbarLtd < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DBAR_LTD, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DBAR_LTD, **kwargs)
     end
   end
 end

--- a/lib/zint/dbaromn.rb
+++ b/lib/zint/dbaromn.rb
@@ -1,8 +1,8 @@
 module Zint
   # GS1 DataBar Omnidirectional
   class DbarOmn < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DBAR_OMN, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DBAR_OMN, **kwargs)
     end
   end
 end

--- a/lib/zint/dbaromnstk.rb
+++ b/lib/zint/dbaromnstk.rb
@@ -1,8 +1,8 @@
 module Zint
   # GS1 DataBar Stacked Omnidirectional
   class DbarOmnstk < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DBAR_OMNSTK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DBAR_OMNSTK, **kwargs)
     end
   end
 end

--- a/lib/zint/dbarstk.rb
+++ b/lib/zint/dbarstk.rb
@@ -1,8 +1,8 @@
 module Zint
   # GS1 DataBar Stacked
   class DbarStk < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DBAR_STK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DBAR_STK, **kwargs)
     end
   end
 end

--- a/lib/zint/dot_code.rb
+++ b/lib/zint/dot_code.rb
@@ -1,8 +1,8 @@
 module Zint
   # DotCode
   class DotCode < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DOTCODE, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DOTCODE, **kwargs)
     end
   end
 end

--- a/lib/zint/dpd.rb
+++ b/lib/zint/dpd.rb
@@ -1,8 +1,8 @@
 module Zint
   # DPD Code
   class Dpd < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DPD, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DPD, **kwargs)
     end
   end
 end

--- a/lib/zint/dpident.rb
+++ b/lib/zint/dpident.rb
@@ -1,8 +1,8 @@
 module Zint
   # Deutsche Post Identcode
   class Dpident < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DPIDENT, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DPIDENT, **kwargs)
     end
   end
 end

--- a/lib/zint/dpleit.rb
+++ b/lib/zint/dpleit.rb
@@ -1,8 +1,8 @@
 module Zint
   # Deutsche Post Leitcode
   class Dpleit < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_DPLEIT, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_DPLEIT, **kwargs)
     end
   end
 end

--- a/lib/zint/ean128.rb
+++ b/lib/zint/ean128.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class Ean128 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_EAN128, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_EAN128, **kwargs)
     end
   end
 end

--- a/lib/zint/ean14.rb
+++ b/lib/zint/ean14.rb
@@ -1,8 +1,8 @@
 module Zint
   # EAN-14
   class Ean14 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_EAN14, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_EAN14, **kwargs)
     end
   end
 end

--- a/lib/zint/eanx.rb
+++ b/lib/zint/eanx.rb
@@ -1,8 +1,8 @@
 module Zint
   # EAN (European Article Number)
   class Eanx < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_EANX, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_EANX, **kwargs)
     end
   end
 end

--- a/lib/zint/eanxchk.rb
+++ b/lib/zint/eanxchk.rb
@@ -1,8 +1,8 @@
 module Zint
   # EAN + Check Digit
   class EanxChk < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_EANX_CHK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_EANX_CHK, **kwargs)
     end
   end
 end

--- a/lib/zint/excode39.rb
+++ b/lib/zint/excode39.rb
@@ -1,8 +1,8 @@
 module Zint
   #  Extended Code 39
   class Excode39 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_EXCODE39, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_EXCODE39, **kwargs)
     end
   end
 end

--- a/lib/zint/fim.rb
+++ b/lib/zint/fim.rb
@@ -1,8 +1,8 @@
 module Zint
   # Facing Identification Mark
   class Fim < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_FIM, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_FIM, **kwargs)
     end
   end
 end

--- a/lib/zint/flat.rb
+++ b/lib/zint/flat.rb
@@ -1,8 +1,8 @@
 module Zint
   # Flattermarken
   class Flat < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_FLAT, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_FLAT, **kwargs)
     end
   end
 end

--- a/lib/zint/grid_matrix.rb
+++ b/lib/zint/grid_matrix.rb
@@ -1,8 +1,8 @@
 module Zint
   # Grid Matrix
   class GridMatrix < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_GRIDMATRIX, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_GRIDMATRIX, **kwargs)
     end
   end
 end

--- a/lib/zint/gs1_128.rb
+++ b/lib/zint/gs1_128.rb
@@ -3,8 +3,8 @@ module Zint
   # GS1-128
   class Gs1_128 < Barcode
     # standard:enable Naming/ClassAndModuleCamelCase
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_GS1_128, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_GS1_128, **kwargs)
     end
   end
 end

--- a/lib/zint/hanxin.rb
+++ b/lib/zint/hanxin.rb
@@ -1,8 +1,8 @@
 module Zint
   # Han Xin (Chinese Sensible) Code
   class Hanxin < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HANXIN, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HANXIN, **kwargs)
     end
   end
 end

--- a/lib/zint/hibc128.rb
+++ b/lib/zint/hibc128.rb
@@ -1,8 +1,8 @@
 module Zint
   # HIBC (Health Industry Barcode) Code 128
   class Hibc128 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HIBC_128, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HIBC_128, **kwargs)
     end
   end
 end

--- a/lib/zint/hibc39.rb
+++ b/lib/zint/hibc39.rb
@@ -1,8 +1,8 @@
 module Zint
   # HIBC Code 39
   class Hibc39 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HIBC_39, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HIBC_39, **kwargs)
     end
   end
 end

--- a/lib/zint/hibcaztec.rb
+++ b/lib/zint/hibcaztec.rb
@@ -1,8 +1,8 @@
 module Zint
   # HIBC Aztec Code
   class HibcAztec < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HIBC_AZTEC, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HIBC_AZTEC, **kwargs)
     end
   end
 end

--- a/lib/zint/hibcblockf.rb
+++ b/lib/zint/hibcblockf.rb
@@ -1,8 +1,8 @@
 module Zint
   # HIBC Codablock-F
   class HibcBlockf < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HIBC_BLOCKF, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HIBC_BLOCKF, **kwargs)
     end
   end
 end

--- a/lib/zint/hibcdm.rb
+++ b/lib/zint/hibcdm.rb
@@ -1,8 +1,8 @@
 module Zint
   # HIBC Data Matrix
   class HibcDm < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HIBC_DM, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HIBC_DM, **kwargs)
     end
   end
 end

--- a/lib/zint/hibcmicpdf.rb
+++ b/lib/zint/hibcmicpdf.rb
@@ -1,8 +1,8 @@
 module Zint
   # HIBC MicroPDF417
   class HibcMicpdf < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HIBC_MICPDF, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HIBC_MICPDF, **kwargs)
     end
   end
 end

--- a/lib/zint/hibcpdf.rb
+++ b/lib/zint/hibcpdf.rb
@@ -1,8 +1,8 @@
 module Zint
   # HIBC PDF417
   class HibcPdf < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HIBC_PDF, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HIBC_PDF, **kwargs)
     end
   end
 end

--- a/lib/zint/hibcqr.rb
+++ b/lib/zint/hibcqr.rb
@@ -1,8 +1,8 @@
 module Zint
   # HIBC QR Code
   class HibcQr < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_HIBC_QR, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_HIBC_QR, **kwargs)
     end
   end
 end

--- a/lib/zint/isbnx.rb
+++ b/lib/zint/isbnx.rb
@@ -1,8 +1,8 @@
 module Zint
   # ISBN
   class Isbnx < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_ISBNX, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_ISBNX, **kwargs)
     end
   end
 end

--- a/lib/zint/itf14.rb
+++ b/lib/zint/itf14.rb
@@ -1,8 +1,8 @@
 module Zint
   # ITF-14
   class Itf14 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_ITF14, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_ITF14, **kwargs)
     end
   end
 end

--- a/lib/zint/japan_post.rb
+++ b/lib/zint/japan_post.rb
@@ -1,8 +1,8 @@
 module Zint
   # Japanese Postal Code
   class JapanPost < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_JAPANPOST, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_JAPANPOST, **kwargs)
     end
   end
 end

--- a/lib/zint/kix.rb
+++ b/lib/zint/kix.rb
@@ -1,8 +1,8 @@
 module Zint
   # Dutch Post KIX Code
   class Kix < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_KIX, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_KIX, **kwargs)
     end
   end
 end

--- a/lib/zint/korea_post.rb
+++ b/lib/zint/korea_post.rb
@@ -1,8 +1,8 @@
 module Zint
   # Korea Post
   class KoreaPost < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_KOREAPOST, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_KOREAPOST, **kwargs)
     end
   end
 end

--- a/lib/zint/logmars.rb
+++ b/lib/zint/logmars.rb
@@ -1,8 +1,8 @@
 module Zint
   # LOGMARS
   class Logmars < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_LOGMARS, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_LOGMARS, **kwargs)
     end
   end
 end

--- a/lib/zint/mailmark.rb
+++ b/lib/zint/mailmark.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class Mailmark < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_MAILMARK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_MAILMARK, **kwargs)
     end
   end
 end

--- a/lib/zint/mailmark_2d.rb
+++ b/lib/zint/mailmark_2d.rb
@@ -1,8 +1,8 @@
 module Zint
   # Royal Mail 2D Mailmark (CMDM) (Data Matrix)
   class Mailmark2D < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_MAILMARK_2D, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_MAILMARK_2D, **kwargs)
     end
   end
 end

--- a/lib/zint/mailmark_4s.rb
+++ b/lib/zint/mailmark_4s.rb
@@ -1,8 +1,8 @@
 module Zint
   # Royal Mail 4-State Mailmark
   class Mailmark4S < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_MAILMARK_4S, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_MAILMARK_4S, **kwargs)
     end
   end
 end

--- a/lib/zint/maxi_code.rb
+++ b/lib/zint/maxi_code.rb
@@ -1,8 +1,8 @@
 module Zint
   # MaxiCode
   class MaxiCode < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_MAXICODE, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_MAXICODE, **kwargs)
     end
   end
 end

--- a/lib/zint/micro_pdf417.rb
+++ b/lib/zint/micro_pdf417.rb
@@ -1,8 +1,8 @@
 module Zint
   # MicroPDF417
   class MicroPdf417 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_MICROPDF417, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_MICROPDF417, **kwargs)
     end
   end
 end

--- a/lib/zint/micro_qr.rb
+++ b/lib/zint/micro_qr.rb
@@ -1,8 +1,8 @@
 module Zint
   # Micro QR Code
   class MicroQr < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_MICROQR, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_MICROQR, **kwargs)
     end
   end
 end

--- a/lib/zint/msiplessey.rb
+++ b/lib/zint/msiplessey.rb
@@ -1,8 +1,8 @@
 module Zint
   # MSI Plessey
   class MsiPlessey < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_MSI_PLESSEY, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_MSI_PLESSEY, **kwargs)
     end
   end
 end

--- a/lib/zint/nve18.rb
+++ b/lib/zint/nve18.rb
@@ -1,8 +1,8 @@
 module Zint
   # NVE-18 (SSCC-18)
   class Nve18 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_NVE18, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_NVE18, **kwargs)
     end
   end
 end

--- a/lib/zint/one_code.rb
+++ b/lib/zint/one_code.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class OneCode < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_ONECODE, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_ONECODE, **kwargs)
     end
   end
 end

--- a/lib/zint/pdf417.rb
+++ b/lib/zint/pdf417.rb
@@ -1,8 +1,8 @@
 module Zint
   # PDF417
   class Pdf417 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_PDF417, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_PDF417, **kwargs)
     end
   end
 end

--- a/lib/zint/pdf417comp.rb
+++ b/lib/zint/pdf417comp.rb
@@ -1,8 +1,8 @@
 module Zint
   # Compact PDF417 (Truncated PDF417)
   class Pdf417comp < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_PDF417COMP, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_PDF417COMP, **kwargs)
     end
   end
 end

--- a/lib/zint/pdf417trunc.rb
+++ b/lib/zint/pdf417trunc.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class Pdf417trunc < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_PDF417TRUNC, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_PDF417TRUNC, **kwargs)
     end
   end
 end

--- a/lib/zint/pharma.rb
+++ b/lib/zint/pharma.rb
@@ -1,8 +1,8 @@
 module Zint
   # Pharmacode One-Track
   class Pharma < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_PHARMA, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_PHARMA, **kwargs)
     end
   end
 end

--- a/lib/zint/pharmatwo.rb
+++ b/lib/zint/pharmatwo.rb
@@ -1,8 +1,8 @@
 module Zint
   # Pharmacode Two-Track
   class PharmaTwo < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_PHARMA_TWO, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_PHARMA_TWO, **kwargs)
     end
   end
 end

--- a/lib/zint/planet.rb
+++ b/lib/zint/planet.rb
@@ -1,8 +1,8 @@
 module Zint
   # USPS PLANET
   class Planet < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_PLANET, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_PLANET, **kwargs)
     end
   end
 end

--- a/lib/zint/plessey.rb
+++ b/lib/zint/plessey.rb
@@ -1,8 +1,8 @@
 module Zint
   # UK Plessey
   class Plessey < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_PLESSEY, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_PLESSEY, **kwargs)
     end
   end
 end

--- a/lib/zint/postnet.rb
+++ b/lib/zint/postnet.rb
@@ -1,8 +1,8 @@
 module Zint
   # USPS (U.S. Postal Service) POSTNET
   class Postnet < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_POSTNET, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_POSTNET, **kwargs)
     end
   end
 end

--- a/lib/zint/pzn.rb
+++ b/lib/zint/pzn.rb
@@ -1,8 +1,8 @@
 module Zint
   # Pharmazentralnummer
   class Pzn < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_PZN, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_PZN, **kwargs)
     end
   end
 end

--- a/lib/zint/qr.rb
+++ b/lib/zint/qr.rb
@@ -10,8 +10,8 @@ module Zint
     # Current ECC level of QR code
     attr_reader :ecc_level
 
-    def initialize(value: nil, input_file: nil, ecc_level: ECC_LEVEL_L, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_QRCODE, options: options.merge(option_1: ecc_level))
+    def initialize(value: nil, input_file: nil, ecc_level: ECC_LEVEL_L, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_QRCODE, **kwargs.merge(option_1: ecc_level))
       @ecc_level = ecc_level
     end
   end

--- a/lib/zint/rmqr.rb
+++ b/lib/zint/rmqr.rb
@@ -1,8 +1,8 @@
 module Zint
   # Rectangular Micro QR Code (rMQR)
   class Rmqr < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_RMQR, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_RMQR, **kwargs)
     end
   end
 end

--- a/lib/zint/rss14.rb
+++ b/lib/zint/rss14.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class Rss14 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_RSS14, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_RSS14, **kwargs)
     end
   end
 end

--- a/lib/zint/rss14stack.rb
+++ b/lib/zint/rss14stack.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class Rss14stack < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_RSS14STACK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_RSS14STACK, **kwargs)
     end
   end
 end

--- a/lib/zint/rss14stackomni.rb
+++ b/lib/zint/rss14stackomni.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class Rss14stackOmni < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_RSS14STACK_OMNI, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_RSS14STACK_OMNI, **kwargs)
     end
   end
 end

--- a/lib/zint/rssexp.rb
+++ b/lib/zint/rssexp.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class RssExp < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_RSS_EXP, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_RSS_EXP, **kwargs)
     end
   end
 end

--- a/lib/zint/rssexpstack.rb
+++ b/lib/zint/rssexpstack.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class RssExpstack < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_RSS_EXPSTACK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_RSS_EXPSTACK, **kwargs)
     end
   end
 end

--- a/lib/zint/rssltd.rb
+++ b/lib/zint/rssltd.rb
@@ -1,8 +1,8 @@
 module Zint
   # Legacy
   class RssLtd < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_RSS_LTD, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_RSS_LTD, **kwargs)
     end
   end
 end

--- a/lib/zint/telepen.rb
+++ b/lib/zint/telepen.rb
@@ -1,8 +1,8 @@
 module Zint
   # Telepen Alpha
   class Telepen < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_TELEPEN, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_TELEPEN, **kwargs)
     end
   end
 end

--- a/lib/zint/telepennum.rb
+++ b/lib/zint/telepennum.rb
@@ -1,8 +1,8 @@
 module Zint
   # Telepen Numeric
   class TelepenNum < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_TELEPEN_NUM, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_TELEPEN_NUM, **kwargs)
     end
   end
 end

--- a/lib/zint/ultra.rb
+++ b/lib/zint/ultra.rb
@@ -1,8 +1,8 @@
 module Zint
   # Ultracode
   class Ultra < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_ULTRA, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_ULTRA, **kwargs)
     end
   end
 end

--- a/lib/zint/upc_a.rb
+++ b/lib/zint/upc_a.rb
@@ -1,8 +1,8 @@
 module Zint
   # UPC-A
   class UpcA < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_UPCA, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_UPCA, **kwargs)
     end
   end
 end

--- a/lib/zint/upc_a_chk.rb
+++ b/lib/zint/upc_a_chk.rb
@@ -1,8 +1,8 @@
 module Zint
   # UPC-A + Check Digit
   class UpcAChk < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_UPCA_CHK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_UPCA_CHK, **kwargs)
     end
   end
 end

--- a/lib/zint/upc_e.rb
+++ b/lib/zint/upc_e.rb
@@ -1,8 +1,8 @@
 module Zint
   # UPC-E
   class UpcE < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_UPCE, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_UPCE, **kwargs)
     end
   end
 end

--- a/lib/zint/upc_e_chk.rb
+++ b/lib/zint/upc_e_chk.rb
@@ -1,8 +1,8 @@
 module Zint
   # UPC-E + Check Digit
   class UpcEChk < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_UPCE_CHK, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_UPCE_CHK, **kwargs)
     end
   end
 end

--- a/lib/zint/upnqr.rb
+++ b/lib/zint/upnqr.rb
@@ -1,8 +1,8 @@
 module Zint
   # UPNQR (Univerzalnega Plačilnega Naloga QR)
   class Upnqr < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_UPNQR, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_UPNQR, **kwargs)
     end
   end
 end

--- a/lib/zint/upu_s10.rb
+++ b/lib/zint/upu_s10.rb
@@ -1,8 +1,8 @@
 module Zint
   # Universal Postal Union S10
   class UpuS10 < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_UPU_S10, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_UPU_S10, **kwargs)
     end
   end
 end

--- a/lib/zint/uspsimail.rb
+++ b/lib/zint/uspsimail.rb
@@ -1,8 +1,8 @@
 module Zint
   # USPS Intelligent Mail (OneCode)
   class UspsImail < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_USPS_IMAIL, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_USPS_IMAIL, **kwargs)
     end
   end
 end

--- a/lib/zint/vin.rb
+++ b/lib/zint/vin.rb
@@ -1,8 +1,8 @@
 module Zint
   # Vehicle Identification Number
   class Vin < Barcode
-    def initialize(value: nil, input_file: nil, options: {})
-      super(value: value, input_file: input_file, type: Zint::BARCODE_VIN, options: options)
+    def initialize(value: nil, input_file: nil, **kwargs)
+      super(value: value, input_file: input_file, symbology: Zint::BARCODE_VIN, **kwargs)
     end
   end
 end

--- a/spec/zint/barcode_spec.rb
+++ b/spec/zint/barcode_spec.rb
@@ -79,7 +79,7 @@ module Zint
       it "exports colored barcode to buffer from value" do
         require "digest/md5"
 
-        bitmap = described_class.new(value: "Test", type: Zint::BARCODE_ULTRA).to_bitmap
+        bitmap = described_class.new(value: "Test", symbology: Zint::BARCODE_ULTRA).to_bitmap
 
         require "chunky_png"
         png = ChunkyPNG::Image.new(bitmap.width, bitmap.height, ChunkyPNG::Color::TRANSPARENT)
@@ -173,7 +173,7 @@ module Zint
       end
 
       it "exports barcode as vector of circles" do
-        v = described_class.new(value: "ABC", type: Zint::BARCODE_MAXICODE).to_vector
+        v = described_class.new(value: "ABC", symbology: Zint::BARCODE_MAXICODE).to_vector
         strs = v.each_circle.to_a
         expect(strs.size).to eq(3)
         expect(strs[0].x).to be >= 1.0
@@ -183,7 +183,7 @@ module Zint
       end
 
       it "exports barcode as vector of hexagons" do
-        v = described_class.new(value: "ABC", type: Zint::BARCODE_MAXICODE).to_vector
+        v = described_class.new(value: "ABC", symbology: Zint::BARCODE_MAXICODE).to_vector
         strs = v.each_hexagon.to_a
         expect(strs.size).to be > 100
         expect(strs[0].x).to be >= 1.0


### PR DESCRIPTION
This makes `Barcode.new` (and its derivations) more intuitive. Also use the setters in `Barcode` instead of writing direct to `Zint::Symbol`.